### PR TITLE
Add support for Linux ARM64/aarch64

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,22 +16,9 @@ jobs:
         CONFIG: linux_64_r_base4.3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_r_base4.2:
-        CONFIG: linux_aarch64_r_base4.2
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
-      linux_aarch64_r_base4.3:
-        CONFIG: linux_aarch64_r_base4.3
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,14 @@ jobs:
         CONFIG: linux_64_r_base4.3
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_r_base4.2:
+        CONFIG: linux_aarch64_r_base4.2
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_aarch64_r_base4.3:
+        CONFIG: linux_aarch64_r_base4.3
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -60,7 +60,10 @@ jobs:
         if EXIST LICENSE.txt (
           copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
         )
-        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
+        if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
+          set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+        )
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/.ci_support/linux_aarch64_r_base4.2.yaml
+++ b/.ci_support/linux_aarch64_r_base4.2.yaml
@@ -1,3 +1,5 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_aarch64_r_base4.2.yaml
+++ b/.ci_support/linux_aarch64_r_base4.2.yaml
@@ -1,0 +1,24 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cran_mirror:
+- https://cran.r-project.org
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- '4.2'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_r_base4.3.yaml
+++ b/.ci_support/linux_aarch64_r_base4.3.yaml
@@ -1,3 +1,5 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_aarch64_r_base4.3.yaml
+++ b/.ci_support/linux_aarch64_r_base4.3.yaml
@@ -1,0 +1,24 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cran_mirror:
+- https://cran.r-project.org
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- '4.3'
+target_platform:
+- linux-aarch64

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,11 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -75,6 +70,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+
+
+matrix:
+  include:
+    - env: CONFIG=linux_aarch64_r_base4.2 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+    - env: CONFIG=linux_aarch64_r_base4.3 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+      os: linux
+      arch: arm64
+      dist: focal
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
+  - if [[ "${TRAVIS_PULL_REQUEST:-}" == "false" ]]; then export IS_PR_BUILD="False"; else export IS_PR_BUILD="True"; fi
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then CONDA_FORGE_DOCKER_RUN_ARGS="--network=host --security-opt=seccomp=unconfined" ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ About r-filelock-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/r-filelock-feedstock/blob/main/LICENSE.txt)
 
+
 About r-filelock
 ----------------
 
@@ -11,6 +12,7 @@ Home: https://github.com/r-lib/filelock#readme
 Package license: MIT
 
 Summary: Place an exclusive or shared lock on a file. It uses 'LockFile' on Windows and 'fcntl' locks on Unix-like systems.
+
 About r-filelock
 ----------------
 
@@ -24,7 +26,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://app.travis-ci.com/conda-forge/r-filelock-feedstock">
+        <img alt="linux" src="https://img.shields.io/travis/com/conda-forge/r-filelock-feedstock/main.svg?label=Linux">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -49,6 +58,20 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1135&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-filelock-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_r_base4.3" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_r_base4.2</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1135&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-filelock-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_r_base4.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_r_base4.3</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1135&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-filelock-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_r_base4.3" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,4 +10,5 @@ github:
   tooling_branch_name: main
 provider:
   win: azure
+  linux_aarch64: default
 test: native_and_emulated


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

I needed to build `bioconductor-biocfilecache` on Linux aarch64 but currently it fails with the following error:
```
12:31:19 BIOCONDA INFO (OUT)   File "/opt/conda/lib/python3.8/site-packages/boa/cli/mambabuild.py", line 133, in mamba_get_install_actions
12:31:19 BIOCONDA INFO (OUT)     raise err
12:31:19 BIOCONDA INFO (OUT) conda_build.exceptions.DependencyNeedsBuildingError: Unsatisfiable dependencies for platform linux-aarch64: {MatchSpec("r-filelock")}
12:31:20 BIOCONDA ERROR COMMAND FAILED (exited with 1): docker run -t --net host --rm -v /tmp/tmpn776261y/build_script.bash:/opt/build_script.bash -v /home/mgrigorov/miniconda3/envs/biotest/conda-bld/:/opt/host-conda-bld -v /home/mgrigorov/git/bioconda/bioconda-recipes/recipes/bioconductor-biocfilecache:/opt/recipe -e LC_ADDRESS=en_US.UTF-8 -e LC_NAME=en_US.UTF-8 -e LC_MONETARY=en_US.UTF-8 -e LC_PAPER=en_US.UTF-8 -e LANG=en_US.UTF-8 -e LC_IDENTIFICATION=en_US.UTF-8 -e LC_TELEPHONE=en_US.UTF-8 -e LC_MEASUREMENT=en_US.UTF-8 -e LC_TIME=en_US.UTF-8 -e LC_NUMERIC=en_US.UTF-8 -e HOST_USER_ID=1000 ghcr.io/yikun/bioconda-utils-build-env-cos7-aarch64 /bin/bash /opt/build_script.bash

12:31:20 BIOCONDA ERROR BUILD FAILED recipes/bioconductor-biocfilecache
12:31:20 BIOCONDA INFO (COMMAND) conda build purge
12:31:21 BIOCONDA ERROR BUILD SUMMARY: of 1 recipes, 1 failed and 0 were skipped. Details of recipes and environments follow.
12:31:21 BIOCONDA ERROR BUILD SUMMARY: FAILED recipe recipes/bioconductor-biocfilecache
```

I hope that with the proposed modifications in this PR `r-filelock` will be usable on Linux aarch64.
I used https://github.com/conda-forge/skopeo-feedstock/pull/33 as a reference. Please let me know if this is not enough!